### PR TITLE
Change to ThreadJob

### DIFF
--- a/UpdateManagement-RunCommand.ps1
+++ b/UpdateManagement-RunCommand.ps1
@@ -1,10 +1,52 @@
+
+<#PSScriptInfo
+
+.VERSION 1.0
+
+.GUID 5494503d-d282-435f-99c4-575a66335141
+
+.AUTHOR zachal
+
+.COMPANYNAME Microsoft
+
+.COPYRIGHT 
+
+.TAGS UpdateManagement, Automation
+
+.LICENSEURI 
+
+.PROJECTURI 
+
+.ICONURI 
+
+.EXTERNALMODULEDEPENDENCIES ThreadJob
+
+.REQUIREDSCRIPTS 
+
+.EXTERNALSCRIPTDEPENDENCIES 
+
+.RELEASENOTES
+
+
+.PRIVATEDATA 
+
+#>
+
+<# 
+
+.DESCRIPTION 
+  This script is intended to be run as a part of Update Management Pre/Post scripts. 
+  It uses RunCommand to execute a PowerShell script to stop a service.
+
+#> 
+
 <#
 .SYNOPSIS
  Stop a service on an AzureRM using RunCommand
 
 .DESCRIPTION
   This script is intended to be run as a part of Update Management Pre/Post scripts. 
-  It uses RunCommand to execute a PowerShell script to stop a service
+  It uses RunCommand to execute a PowerShell script to stop a service.
 
 .PARAMETER SoftwareUpdateConfigurationRunContext
   This is a system variable which is automatically passed in by Update Management during a deployment.

--- a/UpdateManagement-Template.ps1
+++ b/UpdateManagement-Template.ps1
@@ -26,13 +26,18 @@ Add-AzureRmAccount `
 $AzureContext = Select-AzureRmSubscription -SubscriptionId $ServicePrincipalConnection.SubscriptionID
 #endregion BoilerplateAuthentication
 
+Write-Output "Input: $SoftwareUpdateConfigurationRunContext"
 #If you wish to use the run context, it must be converted from JSON
 $context = ConvertFrom-Json  $SoftwareUpdateConfigurationRunContext
-#Access the properties of the SoftwareUpdateConfigurationRunContext
-$vmIds = $context.SoftwareUpdateConfigurationSettings.AzureVirtualMachines
-$runId = $context.SoftwareUpdateConfigurationRunId
+Write-Output "Context: $context" 
+$RunId = $context.SoftwareUpdateConfigurationRunId
+Write-Output "Run ID: $RunID"
+#Configuration settings is another JSON and must be parsed again
+$Settings = ConvertFrom-Json $context.SoftwareUpdateConfigurationSettings
+Write-Output "List of settings: $Settings"
+$VmIds = $Settings.AzureVirtualMachines
+Write-Output "Azure VMs: $VmIds"
 
-Write-Output $context
 
 #Example: How to create and write to a variable using the pre-script:
 <#

--- a/UpdateManagement-Template.ps1
+++ b/UpdateManagement-Template.ps1
@@ -1,3 +1,45 @@
+
+<#PSScriptInfo
+
+.VERSION 1.1
+
+.GUID 5a1ed24c-9099-4921-a135-bfc13213619b
+
+.AUTHOR zachal
+
+.COMPANYNAME Microsoft
+
+.COPYRIGHT 
+
+.TAGS UpdateManagement, Automation
+
+.LICENSEURI 
+
+.PROJECTURI 
+
+.ICONURI 
+
+.EXTERNALMODULEDEPENDENCIES 
+
+.REQUIREDSCRIPTS 
+
+.EXTERNALSCRIPTDEPENDENCIES 
+
+.RELEASENOTES
+
+
+.PRIVATEDATA 
+
+#>
+
+<# 
+
+.DESCRIPTION 
+ This is a template script for Update Management pre/post actions.
+ It contains a basic list of common tasks and can be used to write your own scripts. 
+
+#> 
+
 <#
 .SYNOPSIS
  Barebones script for Update Management Pre/Post

--- a/UpdateManagement-TurnOffVms.ps1
+++ b/UpdateManagement-TurnOffVms.ps1
@@ -1,3 +1,48 @@
+
+<#PSScriptInfo
+
+.VERSION 1.0
+
+.GUID 9606f2a1-49f8-4a67-91d6-23fc6ebf5b3b
+
+.AUTHOR zachal
+
+.COMPANYNAME Microsoft 
+
+.COPYRIGHT 
+
+.TAGS UpdateManagement, Automation
+
+.LICENSEURI 
+
+.PROJECTURI 
+
+.ICONURI 
+
+.EXTERNALMODULEDEPENDENCIES ThreadJob
+
+.REQUIREDSCRIPTS 
+
+.EXTERNALSCRIPTDEPENDENCIES 
+
+.RELEASENOTES
+
+
+.PRIVATEDATA 
+
+#>
+
+<# 
+
+.DESCRIPTION 
+ This script is intended to be run as a part of Update Management Pre/Post scripts.
+It requires a RunAs account.
+This script will ensure all Azure VMs in the Update Deployment are running so they recieve updates.
+This script works with the Turn Off VMs script. It will store the names of machines that were started in an Automation variable so only those machines are turned back off when the deployment is finished.
+ 
+
+#> 
+
 #requires -Modules ThreadJob
 <#
 .SYNOPSIS

--- a/UpdateManagement-TurnOffVms.ps1
+++ b/UpdateManagement-TurnOffVms.ps1
@@ -1,3 +1,4 @@
+#requires -Modules ThreadJob
 <#
 .SYNOPSIS
  Stop VMs that were started as part of an Update Management deployment

--- a/UpdateManagement-TurnOffVms.ps1
+++ b/UpdateManagement-TurnOffVms.ps1
@@ -46,6 +46,12 @@ $runId = "PrescriptContext" + $context.SoftwareUpdateConfigurationRunId
 #Retrieve the automation variable, which we named using the runID from our run context. 
 #See: https://docs.microsoft.com/en-us/azure/automation/automation-variables#activities
 $variable = Get-AutomationVariable -Name $runId
+if (!$variable) 
+{
+    Write-Output "No machines to turn off"
+    return
+}
+
 $vmIds = $variable -split ","
 $stoppableStates = "starting", "running"
 $jobIDs= New-Object System.Collections.Generic.List[System.Object]

--- a/UpdateManagement-TurnOnVms.ps1
+++ b/UpdateManagement-TurnOnVms.ps1
@@ -31,6 +31,22 @@ $context = ConvertFrom-Json  $SoftwareUpdateConfigurationRunContext
 $vmIds = $context.SoftwareUpdateConfigurationSettings.AzureVirtualMachines
 $runId = "PrescriptContext" + $context.SoftwareUpdateConfigurationRunId
 
+
+if (!$vmIds) 
+{
+    #Workaround: Had to change JSON formatting
+    $Settings = ConvertFrom-Json $context.SoftwareUpdateConfigurationSettings
+    #Write-Output "List of settings: $Settings"
+    $VmIds = $Settings.AzureVirtualMachines
+    #Write-Output "Azure VMs: $VmIds"
+    if (!$vmIds) 
+    {
+        Write-Output "No Azure VMs found"
+        return
+    }
+}
+
+
 #region BoilerplateAuthentication
 #This requires a RunAs account
 $ServicePrincipalConnection = Get-AutomationConnection -Name 'AzureRunAsConnection'

--- a/UpdateManagement-TurnOnVms.ps1
+++ b/UpdateManagement-TurnOnVms.ps1
@@ -1,3 +1,54 @@
+
+<#PSScriptInfo
+
+.VERSION 1.1
+
+.GUID 5fbe9d16-981d-4a88-874c-365d46c1fcc2
+
+.AUTHOR zachal
+
+.COMPANYNAME Microsoft
+
+.COPYRIGHT 
+
+.TAGS UpdateManagement, Automation
+
+.LICENSEURI 
+
+.PROJECTURI 
+
+.ICONURI 
+
+.EXTERNALMODULEDEPENDENCIES ThreadJob
+
+.REQUIREDSCRIPTS 
+
+.EXTERNALSCRIPTDEPENDENCIES 
+
+.RELEASENOTES
+
+
+.PRIVATEDATA 
+
+#>
+
+<# 
+
+.DESCRIPTION 
+ This script is intended to be run as a part of Update Management Pre/Post scripts.
+ 
+
+It requires a RunAs account and the usage of the Turn On VMs script as a pre-deployment script.
+ 
+
+This script will ensure all Azure VMs in the Update Deployment are turned off after they recieve updates.
+ 
+
+This script reads the name of machines that were started by Update Management via the Turn On VMs script
+
+
+#> 
+
 #requires -Modules ThreadJob
 <#
 .SYNOPSIS


### PR DESCRIPTION
Feedback:
Jobs are too heavyweight for the AA sandbox, move to JobThreads instead. 

Also, query for the specific jobs created in this script and not all jobs since that has the potential to peek at jobs running in the same sandbox. 